### PR TITLE
event propogation stopped, so it does not trigger child ng-click

### DIFF
--- a/dist/ion-floating-menu.js
+++ b/dist/ion-floating-menu.js
@@ -36,7 +36,7 @@
                 text: '@?',
                 textClass: '@?',
                 bottom: '@?'},
-            template: '<ul ng-click="click()" id="floating-button" ng-class="{\'center\': isCentered}" ng-style="{\'bottom\' : \'{{bottom}}\' }">' +
+            template: '<ul ng-click="click(); $event.stopPropagation();" id="floating-button" ng-class="{\'center\': isCentered}" ng-style="{\'bottom\' : \'{{bottom}}\' }">' +
                     '<li ng-class="buttonClass" ng-style="{\'background-color\': buttonColor }">' +
                     '<a><span ng-if="text" class="label-container"><span class="label" ng-class="textClass" ng-bind="text"></span></span><i class="icon menu-icon" ng-class="{ \'{{icon}}\' : true}" ng-style="{\'color\': iconColor }"></i></a>' +
                     '</li>' +
@@ -108,7 +108,7 @@
                 text: '@?',
                 textClass: '@?'},
             template:
-                    '<li ng-click="click()" ng-class="buttonClass" ng-style="{\'background-color\': buttonColor }">' +
+                    '<li ng-click="click(); $event.stopPropagation();" ng-class="buttonClass" ng-style="{\'background-color\': buttonColor }">' +
                     '<span ng-if="text" class="label-container"><span class="label" ng-class="textClass" ng-bind="text"></span></span>' +
                     '<img ng-if="iconImagePath" class="menu-icon" ng-class="iconImageClass" ng-src="{{iconImagePath}}"/>' +
                     '<i ng-if="!iconImagePath" class="icon menu-icon" ng-class="{ \'{{icon}}\' : true}" ng-style="{\'color\': iconColor }"></i>' +


### PR DESCRIPTION
Resolved minor issue. 

I have a list of items in my mobile application, each item has a click bound to it. Above them I have ion-floating-menu. 

Now when clicking on ion-floating-button or ion-floating-item, ng-click of the item below the button also got triggered every time. Which according to me, nobody wants. 

![image](https://cloud.githubusercontent.com/assets/17405938/21304207/92914f4a-c5e9-11e6-865f-36f510a4ce64.png)
